### PR TITLE
use parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <url>https://github.com/codenvy/che-installer</url>
     </scm>
     <properties>
-        <eclipse-che.version>${che.version}</eclipse-che.version>
+        <eclipse-che.version>${project.parent.version}</eclipse-che.version>
     </properties>
     <repositories>
         <repository>


### PR DESCRIPTION
as ${che.version} was moved to codenvy-depmgt we need other way to resolve che version.
